### PR TITLE
Fix admin page crash

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Decap CMS</title>
-  <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>
+  <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js" defer></script>
 </head>
 <body>
 </body>


### PR DESCRIPTION
## Summary
- set `defer` on Decap CMS script so `<body>` exists before the script runs

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_68842bc6be14832dac15cdf3442d10f2