### PR TITLE
Fix wrangler secret step

### DIFF
--- a/.github/workflows/deploy-cloudflare-oauth-proxy.yml
+++ b/.github/workflows/deploy-cloudflare-oauth-proxy.yml
@@ -29,7 +29,6 @@ jobs:
       working-directory: worker
       run: |
         echo 'name = "decap-oauth-proxy"' > wrangler.toml
-        echo 'type = "javascript"' >> wrangler.toml
         echo 'account_id = "${{ secrets.CLOUDFLARE_ACCOUNT_ID }}"' >> wrangler.toml
         echo 'workers_dev = true' >> wrangler.toml
         echo 'compatibility_date = "2024-07-28"' >> wrangler.toml
@@ -38,6 +37,7 @@ jobs:
       env:
         GITHUB_CLIENT_ID: ${{ secrets.GIT_CLIENT_ID }}
         GITHUB_CLIENT_SECRET: ${{ secrets.GIT_CLIENT_SECRET }}
+        CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       run: |
         echo "$GITHUB_CLIENT_ID" | wrangler secret put GITHUB_CLIENT_ID
         echo "$GITHUB_CLIENT_SECRET" | wrangler secret put GITHUB_CLIENT_SECRET


### PR DESCRIPTION
## Summary
- pass CLOUDFLARE_API_TOKEN into the secret injection step
- remove deprecated `type` from wrangler configuration generation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_688714bfbec4832db5920458745dff06